### PR TITLE
Fix error in IE

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var requestAnimFrame = (function() {
     function (callback) {
       window.setTimeout(callback, 1000 / 60);
     };
-}());
+}().bind(window));
 
 function decouple(node, event, fn) {
   var eve,


### PR DESCRIPTION
Getting `Invalid Calling Object` in IE11 when scrolling, this fixes that error.

(Source: https://github.com/facebook/fixed-data-table/pull/195/files)